### PR TITLE
fix: specify the correct package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directories:
       - "/"
       - "/apps/**/*"


### PR DESCRIPTION
`npm` is the correct package ecosystem

Fixes (#1)